### PR TITLE
Changed Path Characters

### DIFF
--- a/Base.gd
+++ b/Base.gd
@@ -130,9 +130,9 @@ func save(text,fname):
 func lload(fname):
 	var file = File.new()
 	
-	var baseFolder = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS) + "\\TEXTREME"
+	var baseFolder = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS) + "\/TEXTREME"
 	
-	file.open(baseFolder + "\\" + fname + ".txt", file.READ)
+	file.open(baseFolder + "\/" + fname + ".txt", file.READ)
 	var content = file.get_as_text()
 	
 	if !file.is_open():

--- a/Base.gd
+++ b/Base.gd
@@ -114,11 +114,11 @@ func save(text,fname):
 	savename = fname
 	var file = File.new()
 	
-	var baseFolder = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS) + "\\TEXTREME"
+	var baseFolder = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS) + "\/TEXTREME"
 	
 	Directory.new().make_dir(baseFolder)
 	
-	file.open(baseFolder + "\\" + fname + ".txt", file.WRITE)
+	file.open(baseFolder + "\/" + fname + ".txt", file.WRITE)
 	
 	if !file.is_open():
 		printerr("Failed to save the file!")


### PR DESCRIPTION
As I've thought when writing issue #2 the path character was only for Windows, not working in linux.
With this it should work in both as [can be read here](http://docs.godotengine.org/en/3.0/tutorials/io/data_paths.html#path-separators), but **PLEASE TEST**, as I have got no Windows to test.
There should be more wrong paths, and in this pull request I have corrected just the save and load functionalities.